### PR TITLE
Updated text justification from 10 characters to 20

### DIFF
--- a/littlechef_rackspace/commands.py
+++ b/littlechef_rackspace/commands.py
@@ -65,7 +65,7 @@ class RackspaceListFlavors(Command):
     def execute(self, progress=sys.stderr, **kwargs):
         flavors = self.rackspace_api.list_flavors()
         for flavor in flavors:
-            progress.write('{0}{1}\n'.format(flavor['id'].ljust(10), flavor['name']))
+            progress.write('{0}{1}\n'.format(flavor['id'].ljust(20), flavor['name']))
 
 class RackspaceListNetworks(Command):
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -98,8 +98,8 @@ class RackspaceListFlavorsTest(unittest.TestCase):
         self.command.execute(progress=progress)
 
         self.assertEquals([
-                              '{0}{1}'.format(flavor1['id'].ljust(10), flavor1['name']),
-                              '{0}{1}'.format(flavor2['id'].ljust(10), flavor2['name'])
+                              '{0}{1}'.format(flavor1['id'].ljust(20), flavor1['name']),
+                              '{0}{1}'.format(flavor2['id'].ljust(20), flavor2['name'])
                           ], progress.getvalue().splitlines())
 
 


### PR DESCRIPTION
Performance flavors were added to the rackspace flavors list and
they have a bit more text than the standard flavors. This caused a confusing
looking list like:

7         15GB Standard Instance
8         30GB Standard Instance
performance1-11 GB Performance
performance1-22 GB Performance

Updated it to look like:

7                   15GB Standard Instance
8                   30GB Standard Instance
performance1-1      1 GB Performance
performance1-2      2 GB Performance
