### PR TITLE
Remove redundant hostname argument, add --dry-run argument

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,13 @@
+## 0.7
+
+* Display performance flavors better (Samuel Toriel)
+* Support creating IAD public cloud resources
+* Add --dry-run argument for showing what arguments
+  a node will be created with, but not actually executing
+  the creation.
+* BREAKING: Remove 'hostname' argument.  Nodes are 
+  created with the same hostname as their API name.
+
 ## 0.6 (2013-04-25)
 
 * Support creating SYD resources (if your account has Sydney OpenStack

--- a/littlechef_rackspace/api.py
+++ b/littlechef_rackspace/api.py
@@ -35,7 +35,7 @@ class RackspaceApi(object):
         return [{ "id": size.id, "name": size.name}
                 for size in conn.list_sizes()]
 
-    def create_node(self, image, flavor, node_name, public_key_file, networks=None, progress=None):
+    def create_node(self, image, flavor, name, public_key_file, networks=None, progress=None):
         create_kwargs = {}
         if networks:
             fake_networks = [OpenStackNetwork(n, None, None, self) for n in networks]
@@ -47,9 +47,9 @@ class RackspaceApi(object):
                                bandwidth=None, price=None, driver=conn)
 
         if progress:
-            progress.write("Creating node {0} (image: {1}, flavor: {2})...\n".format(node_name, image, flavor))
+            progress.write("Creating node {0} (image: {1}, flavor: {2})...\n".format(name, image, flavor))
 
-        node = conn.create_node(name=node_name, image=fake_image,
+        node = conn.create_node(name=name, image=fake_image,
                          size=fake_flavor, ex_files={
                              "/root/.ssh/authorized_keys": public_key_file.read()
                          },
@@ -57,7 +57,7 @@ class RackspaceApi(object):
         password = node.extra.get("password")
 
         if progress:
-            progress.write("Created node {0} (id: {1}, password: {2})\n".format(node_name, node.id, password))
+            progress.write("Created node {0} (id: {1}, password: {2})\n".format(name, node.id, password))
             progress.write("Waiting for node to become active")
 
         while node.state != NodeState.RUNNING:
@@ -73,6 +73,6 @@ class RackspaceApi(object):
         if progress:
             progress.write("\n")
             progress.write("Node active! (host: {0})\n".format(public_ipv4_address))
-        return Host(name=node_name,
+        return Host(name=name,
                     ip_address=public_ipv4_address,
                     password=password)

--- a/littlechef_rackspace/lib.py
+++ b/littlechef_rackspace/lib.py
@@ -7,25 +7,23 @@ class Host(object):
 
     def __init__(self, name=None, host_string=None, ip_address=None, password=None, environment=None):
         self.name = name
-        self.host_string = host_string
         self.ip_address = ip_address
         self.password = password
         self.environment = environment
 
     def get_host_string(self):
-        if self.host_string:
-            return self.host_string
+        if self.name:
+            return self.name
 
         return self.ip_address
 
     def __repr__(self):
-        return '<Host name={0}, host_string={1}, ip_address={2}, password={3}>'.format(
-            self.name, self.host_string, self.ip_address, self.password
+        return '<Host name={0}, ip_address={1}, password={2}>'.format(
+            self.name, self.ip_address, self.password
         )
 
     def __eq__(self, other):
         return (self.name == other.name and
-                self.host_string == other.host_string and
                 self.ip_address == other.ip_address and
                 self.password == other.password and
                 self.environment == other.environment)

--- a/littlechef_rackspace/runner.py
+++ b/littlechef_rackspace/runner.py
@@ -44,8 +44,8 @@ parser.add_option("-f", "--flavor", dest="flavor",
                   help="Flavor ID")
 parser.add_option("-A", "--username", dest="username",
                   help="Rackspace Username")
-parser.add_option("-N", "--node-name", dest="node_name",
-                  help="Node name")
+parser.add_option("-N", "--name", dest="name",
+                  help="Node name (will become hostname for node)")
 parser.add_option("-K", "--key", dest="key",
                   help="Rackspace API Key")
 parser.add_option("-R", "--region", dest="region", default="",
@@ -59,9 +59,6 @@ parser.add_option("-r", "--runlist", dest="runlist",
 parser.add_option("-e", "--env", dest="environment",
                   help="Environment for newly created node",
                   default=None)
-parser.add_option("-H", "--hostname", dest="hostname",
-                  help="Hostname for newly created node (DNS will not be set up -- you must do this manually)",
-                  default=None)
 parser.add_option("-p", "--plugins", dest="plugins",
                   help="Plugins to execute after chef bootstrapping but before chef run e.g, 'save_cloud,save_hosts'",
                   default=None)
@@ -69,6 +66,8 @@ parser.add_option("-P", "--post-plugins", dest="post-plugins",
                   help="Plugins to execute after chef run. e.g, 'mark_node_as_provisioned'",
                   default=None)
 parser.add_option("--skip-opscode-chef", action="store_false", dest="use-opscode-chef")
+parser.add_option("--dry-run", action="store_true", dest="dry_run",
+                  help="When creating a node, do not actually create/deploy")
 parser.add_option("--use-opscode-chef", type="int", dest="use-opscode-chef",
                   help="Integer argument with whether or not to use the OpsCode Chef repositorities (installed with 'fix deploy_chef')",
                   default=None)

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -93,18 +93,18 @@ class RackspaceApiTest(unittest.TestCase):
 
         image_id = "5cebb13a-f783-4f8c-8058-c4182c724ccd"
         flavor_id = "2"
-        node_name = "new-node"
+        name = "new-node"
         public_key = "ssh-file deadbeef dave@isis"
         public_key_io = StringIO(public_key)
         conn.create_node.return_value = self.active_node
 
-        api.create_node(node_name=node_name,
+        api.create_node(name=name,
                         image=image_id,
                         flavor=flavor_id,
                         public_key_file=public_key_io)
 
         call_kwargs = conn.create_node.call_args_list[0][1]
-        self.assertEquals(node_name, call_kwargs['name'])
+        self.assertEquals(name, call_kwargs['name'])
         self.assertEquals(image_id, call_kwargs['image'].id)
         self.assertEquals(flavor_id, call_kwargs['size'].id)
         self.assertEquals({"/root/.ssh/authorized_keys": public_key},
@@ -116,7 +116,7 @@ class RackspaceApiTest(unittest.TestCase):
         network_id_list = ['id1', 'id2', 'id3']
         conn.create_node.return_value = self.active_node
 
-        api.create_node(node_name="some name",
+        api.create_node(name="some name",
                         image="some image",
                         flavor="some flavor",
                         public_key_file=StringIO("some public key"),
@@ -138,7 +138,7 @@ class RackspaceApiTest(unittest.TestCase):
         conn.ex_get_node_details.return_value = self.active_node
 
         with mock.patch('littlechef_rackspace.api.time') as time:
-            api.create_node(node_name="some name",
+            api.create_node(name="some name",
                             image="5cebb13a-f783-4f8c-8058-c4182c724ccd",
                             flavor="2",
                             public_key_file=StringIO("some public key"))
@@ -156,7 +156,7 @@ class RackspaceApiTest(unittest.TestCase):
         self.active_node.extra['password'] = 'password'
         conn.create_node.return_value = self.active_node
 
-        result = api.create_node(node_name="some name",
+        result = api.create_node(name="some name",
                                  image="5cebb13a-f783-4f8c-8058-c4182c724ccd",
                                  flavor="2",
                                  public_key_file=StringIO("some public key"))
@@ -186,18 +186,18 @@ class RackspaceApiTest(unittest.TestCase):
         self.pending_node.extra['password'] = password
 
         with mock.patch('littlechef_rackspace.api.time') as time:
-            node_name = "new node"
+            name = "new node"
             image_id = "dontcare"
             flavor_id = "2"
-            host = api.create_node(node_name=node_name,
+            host = api.create_node(name=name,
                                    image=image_id,
                                    flavor=flavor_id,
                                    public_key_file=StringIO("some key"),
                                    progress=progress)
 
             self.assertEquals([
-                "Creating node {0} (image: {1}, flavor: {2})...".format(node_name, image_id, flavor_id),
-                "Created node {0} (id: {1}, password: {2})".format(node_name, self.pending_node.id, password),
+                "Creating node {0} (image: {1}, flavor: {2})...".format(name, image_id, flavor_id),
+                "Created node {0} (id: {1}, password: {2})".format(name, self.pending_node.id, password),
                 "Waiting for node to become active{0}".format("." * 6),
                 "Node active! (host: {0})".format(host.ip_address)
             ], progress.getvalue().splitlines())

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -6,7 +6,7 @@ from littlechef_rackspace.deploy import ChefDeployer
 class ChefDeployerTest(unittest.TestCase):
 
     def setUp(self):
-        self.host = Host(host_string="test.example.com",
+        self.host = Host(name="test.example.com",
                          ip_address="50.56.57.58")
         self.ohai_data = {
             'cloud': {
@@ -71,7 +71,7 @@ class ChefDeployerTest(unittest.TestCase):
 
         deployer.deploy(self.host)
 
-        littlechef.lib.get_node.assert_any_call(self.host.host_string)
+        littlechef.lib.get_node.assert_any_call(self.host.name)
         node_data.update(self.ohai_data)
         littlechef.chef.save_config.assert_any_call(node_data, force=True)
 
@@ -81,7 +81,7 @@ class ChefDeployerTest(unittest.TestCase):
         deployer = self._get_deployer(key_filename="~/.ssh/id_rsa")
 
         node_data = {}
-        self.host.host_string = None
+        self.host.name = None
         littlechef.lib.get_node.return_value = node_data
 
         deployer.deploy(self.host)
@@ -103,7 +103,7 @@ class ChefDeployerTest(unittest.TestCase):
         predefined_data['run_list'] = runlist
 
         littlechef.chef.save_config.assert_any_call(predefined_data, force=True)
-        littlechef.lib.get_node.assert_any_call(self.host.host_string)
+        littlechef.lib.get_node.assert_any_call(self.host.name)
 
     @mock.patch('littlechef_rackspace.deploy.lc')
     @mock.patch('littlechef_rackspace.deploy.littlechef')
@@ -148,15 +148,6 @@ HostName 50.56.57.58
         self.assertTrue(lc.env.use_ssh_config)
         self.assertEquals(lc.env.ssh_config_path,
                           "./.bootstrap-config_{0}".format(self.host.get_host_string()))
-
-    @mock.patch('littlechef_rackspace.deploy.lc')
-    @mock.patch('littlechef_rackspace.deploy.littlechef')
-    def test_deploy_with_runlist_runs_node_on_ip_address(self, littlechef, lc):
-        deployer = self._get_deployer(key_filename="~/.ssh/id_rsa")
-
-        deployer.deploy(self.host)
-
-        lc.node.assert_any_call(self.host.host_string)
 
     @mock.patch('littlechef_rackspace.deploy.lc')
     @mock.patch('littlechef_rackspace.deploy.littlechef')

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -33,7 +33,7 @@ class RunnerTest(unittest.TestCase):
         self.list_images_command = self.list_images_class.return_value
 
         # Dumb hacks using README.md as a public key because you can't mock out a file() call
-        self.create_args = "create --flavor 2 --image 123 --node-name test-node --username username --key deadbeef --region dfw --public-key README.md".split(' ')
+        self.create_args = "create --flavor 2 --image 123 --name test-node --username username --key deadbeef --region dfw --public-key README.md".split(' ')
 
         list_images_command_string = "list-images --username username --key deadbeef --region REGION --public-key README.md"
         self.dfw_list_images_args = list_images_command_string.replace('REGION', 'dfw').split(' ')
@@ -116,7 +116,7 @@ class RunnerTest(unittest.TestCase):
 
             self.assertEquals("123", call_args["image"])
             self.assertEquals("2", call_args["flavor"])
-            self.assertEquals("test-node", call_args["node_name"])
+            self.assertEquals("test-node", call_args["name"])
             self.assertEquals('README.md', call_args['public_key_file'].name)
 
     def test_create_with_runlist_parses_runlist_into_array(self):


### PR DESCRIPTION
In practice hostname and node name did not differ in our use of
the tool.
