### PR TITLE
Adding in Connection retry

### DIFF
--- a/littlechef_rackspace/deploy.py
+++ b/littlechef_rackspace/deploy.py
@@ -18,8 +18,7 @@ class ChefDeployer(object):
         plugins = plugins or []
         post_plugins = post_plugins or []
 
-        attempts = kwargs.get('connection_attempts', 1)
-        self._setup_ssh_config(host, connection_attempts=attempts)
+        self._setup_ssh_config(host)
         if use_opscode_chef:
             lc.deploy_chef(ask="no")
 
@@ -53,7 +52,7 @@ class ChefDeployer(object):
 
         plugin.execute(node)
 
-    def _setup_ssh_config(self, host, **kwargs):
+    def _setup_ssh_config(self, host):
         """
         New servers are created with 'root' user and an authorized public key
         that is a pair for the private key specified by self.key_filename.
@@ -82,7 +81,7 @@ class ChefDeployer(object):
         lc.env.user = "root"
         lc.env.host = host.get_host_string()
         lc.env.host_string = host.get_host_string()
-        lc.env.connection_attempts = kwargs.get('connection_attempts', 1)
+        lc.env.connection_attempts = 10
 
     def _bootstrap_node(self, host):
         lc.node(host.get_host_string())

--- a/littlechef_rackspace/runner.py
+++ b/littlechef_rackspace/runner.py
@@ -77,9 +77,6 @@ parser.add_option("--use-opscode-chef", type="int", dest="use-opscode-chef",
 parser.add_option("-n", "--networks", dest="networks",
                   help="Comma separated list of network ids to create node with (PublicNet is required)",
                   default=None)
-parser.add_option("--retry-attempts", dest="connection_attempts", type=int,
-                  help="Number of connection attempts for SSH before failing",
-                  default=1)
 
 
 class Runner(object):
@@ -202,9 +199,7 @@ class Runner(object):
             return
 
         public_key = args.get('public_key', "~/.ssh/id_rsa.pub")
-        connection_attempts = args.get('connection_attempts', 1)
         args['public_key_file'] = file(os.path.expanduser(public_key))
-        args['connection_attempts'] = connection_attempts
 
         self._expand_argument(args, 'runlist')
         self._expand_argument(args, 'plugins')

--- a/test/test_deploy.py
+++ b/test/test_deploy.py
@@ -40,6 +40,7 @@ class ChefDeployerTest(unittest.TestCase):
         self.assertEquals("root", lc.env.user)
         self.assertEquals(self.host.get_host_string(), lc.env.host_string)
         self.assertEquals(self.host.get_host_string(), lc.env.host)
+        self.assertEquals(10, lc.env.connection_attempts)
 
     @mock.patch('littlechef_rackspace.deploy.lc')
     @mock.patch('littlechef_rackspace.deploy.littlechef')


### PR DESCRIPTION
The fabric connector was only attempting the SSH connection once when the server became active. A server can go active before SSH is available, so it would error on the failed connection.

Users can now specify how many connection attempts to try before failing.
