### PR TITLE
Fixed misaligned command list

### DIFF
--- a/littlechef_rackspace/runner.py
+++ b/littlechef_rackspace/runner.py
@@ -44,9 +44,12 @@ class RackspaceOptionParser(OptionParser):
     def print_help(self, file=None):
         OptionParser.print_help(self, file)
         print("\nAvailable commands:\n")
+
+        name_width = max(len(c.name) for c in get_command_classes())
+
         for command_class in get_command_classes():
-            print("   {0}\t{1}".format(command_class.name,
-                                       command_class.description))
+            print("   {0}{1}".format(command_class.name.ljust(name_width + 3),
+                                     command_class.description))
         print("")
 
 


### PR DESCRIPTION
Before:
```
Available commands:

   create       Create new Cloud Server and bootstrap Chef
   rebuild      Rebuild existing Cloud Server and bootstrap Chef
   list-images  List available images for a Cloud Servers endpoint
   list-flavors List available flavors for a Cloud Servers endpoint
   list-networks        List available networks for a Cloud Servers endpoint
   list-servers List servers for a region
```

After:
```
Available commands:

   create          Create new Cloud Server and bootstrap Chef
   rebuild         Rebuild existing Cloud Server and bootstrap Chef
   list-images     List available images for a Cloud Servers endpoint
   list-flavors    List available flavors for a Cloud Servers endpoint
   list-networks   List available networks for a Cloud Servers endpoint
   list-servers    List servers for a region
```

Because OCD