### PR TITLE
Attach block storage volumes on create

### DIFF
--- a/littlechef_rackspace/api.py
+++ b/littlechef_rackspace/api.py
@@ -43,6 +43,12 @@ class RackspaceApi(object):
                  "public_ipv4": self._public_ipv4(node)}
                 for node in conn.list_nodes()]
 
+    def list_volumes(self):
+        conn = self._get_conn()
+
+        return [{"id": volume.id, "name": volume.name}
+                for volume in conn.list_volumes()]
+
     def _public_ipv4(self, node):
         # Dumb hack to not select the ipv6 address
         return [ip for ip in node.public_ips if ":" not in ip][0]

--- a/littlechef_rackspace/commands.py
+++ b/littlechef_rackspace/commands.py
@@ -125,6 +125,20 @@ class RackspaceListServers(Command):
                                                 server['public_ipv4']))
 
 
+class RackspaceListVolumes(Command):
+
+    name = "list-volumes"
+    description = "List block storage volumes for a region"
+    requires_api = True
+
+    def execute(self, progress=sys.stderr, **kwargs):
+        volumes = self.rackspace_api.list_volumes()
+
+        for volume in volumes:
+            progress.write('{0}{1}\n'.format(volume['id'].ljust(41),
+                                             volume['name']))
+
+
 class RackspaceRebuild(Command):
 
     name = "rebuild"

--- a/littlechef_rackspace/commands.py
+++ b/littlechef_rackspace/commands.py
@@ -32,7 +32,7 @@ class RackspaceCreate(Command):
         self.chef_deploy = chef_deployer
 
     def execute(self, name, flavor, image, public_key_file,
-                environment=None, networks=None,
+                environment=None, networks=None, volumes=None,
                 progress=sys.stderr, **kwargs):
         create_args = {
             'name': name,
@@ -40,6 +40,7 @@ class RackspaceCreate(Command):
             'image': image,
             'environment': environment,
             'networks': networks,
+            'volumes': volumes,
         }
         create_args.update(kwargs)
 
@@ -52,6 +53,7 @@ class RackspaceCreate(Command):
                                               image=image,
                                               public_key_file=public_key_file,
                                               networks=networks,
+                                              volumes=volumes,
                                               progress=sys.stderr)
         if environment:
             host.environment = environment

--- a/littlechef_rackspace/runner.py
+++ b/littlechef_rackspace/runner.py
@@ -96,6 +96,10 @@ parser.add_option("-n", "--networks", dest="networks",
                   help="Comma separated list of network ids to \
                           create node with (PublicNet is required)",
                   default=None)
+parser.add_option("-v", "--volumes", dest="volumes",
+                  help="Comma separated list of volume ids to \
+                          create node with",
+                  default=None)
 
 
 class Runner(object):
@@ -230,6 +234,7 @@ class Runner(object):
         self._expand_argument(args, 'plugins')
         self._expand_argument(args, 'post-plugins')
         self._expand_argument(args, 'networks')
+        self._expand_argument(args, 'volumes')
 
         if 'use-opscode-chef' in args:
             args['use_opscode_chef'] = bool(args['use-opscode-chef'])

--- a/littlechef_rackspace/runner.py
+++ b/littlechef_rackspace/runner.py
@@ -13,7 +13,8 @@ from commands import (RackspaceCreate,
                       RackspaceListFlavors,
                       RackspaceListNetworks,
                       RackspaceRebuild,
-                      RackspaceListServers)
+                      RackspaceListServers,
+                      RackspaceListVolumes)
 
 
 def get_command_classes():
@@ -22,7 +23,8 @@ def get_command_classes():
             RackspaceListImages,
             RackspaceListFlavors,
             RackspaceListNetworks,
-            RackspaceListServers]
+            RackspaceListServers,
+            RackspaceListVolumes]
 
 
 class FailureMessages:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -1,6 +1,6 @@
 from StringIO import StringIO
 import unittest2 as unittest
-from libcloud.compute.base import NodeImage, Node, NodeSize
+from libcloud.compute.base import NodeImage, Node, NodeSize, StorageVolume
 from libcloud.compute.types import Provider, NodeState
 from libcloud.compute.drivers.openstack import OpenStackNetwork
 
@@ -132,6 +132,22 @@ class RackspaceApiTest(unittest.TestCase):
             'name': network1.name,
             'cidr': network1.cidr}],
             api.list_networks())
+
+    def test_list_volumes_returns_volume_information(self):
+        conn = mock.Mock()
+        api = self._get_api_with_mocked_conn(conn)
+
+        volume1 = StorageVolume('1', 'volume1', 1, None)
+        volume2 = StorageVolume('2', 'volume2', 1, None)
+
+        conn.list_volumes.return_value = [volume1, volume2]
+
+        expected_results = [
+            {'id': volume1.id, 'name': volume1.name},
+            {'id': volume2.id, 'name': volume2.name}
+        ]
+
+        self.assertEquals(expected_results, api.list_volumes())
 
     def test_creates_node(self):
         conn = mock.Mock()

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -8,6 +8,7 @@ from littlechef_rackspace.commands import (RackspaceCreate,
                                            RackspaceListFlavors,
                                            RackspaceListNetworks,
                                            RackspaceListServers,
+                                           RackspaceListVolumes,
                                            RackspaceRebuild)
 from littlechef_rackspace.deploy import ChefDeployer
 from littlechef_rackspace.lib import Host
@@ -214,6 +215,28 @@ class RackspaceListServersTest(unittest.TestCase):
             '{0}{1}{2}'.format(server2['id'].ljust(36 + 5),
                                server2['name'].ljust(20),
                                server2['public_ipv4']),
+        ], progress.getvalue().splitlines())
+
+
+class RackspaceListVolumesTest(unittest.TestCase):
+
+    def setUp(self):
+        self.api = mock.Mock(spec=RackspaceApi)
+        self.command = RackspaceListVolumes(rackspace_api=self.api)
+
+    def test_outputs_servers(self):
+        progress = StringIO()
+        volume1 = {'id': '0', 'name': 'volume1'}
+        volume2 = {'id': '1', 'name': 'volume2'}
+        self.api.list_volumes.return_value = [volume1, volume2]
+
+        self.command.execute(progress=progress)
+
+        self.assertEquals([
+            '{0}{1}'.format(volume1['id'].ljust(36 + 5),
+                               volume1['name']),
+            '{0}{1}'.format(volume2['id'].ljust(36 + 5),
+                               volume2['name']),
         ], progress.getvalue().splitlines())
 
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -45,10 +45,11 @@ class RackspaceCreateTest(unittest.TestCase):
             output_arguments.replace(' ', ''),
             """Creating node with arguments:
 {
-    "environment": "production",
-    "flavor": "flavorId",
     "name": "not-important",
     "image": "imageId",
+    "environment": "production",
+    "volumes":null,
+    "flavor": "flavorId",
     "networks": null
 }
 """.replace(' ', '')
@@ -68,6 +69,7 @@ class RackspaceCreateTest(unittest.TestCase):
                                              flavor=flavor,
                                              public_key_file=public_key_file,
                                              networks=None,
+                                             volumes=None,
                                              progress=sys.stderr)
 
     def test_deploys_to_host_with_kwargs(self):

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -312,6 +312,25 @@ class RunnerTest(unittest.TestCase):
             self.assertEquals([public_net_id, custom_net_id],
                               call_args.get('networks'))
 
+    def test_create_with_volumes_passes_volumes(self):
+        with mock.patch.multiple(
+                "littlechef_rackspace.runner",
+                RackspaceApi=self.api_class,
+                ChefDeployer=self.deploy_class,
+                RackspaceCreate=self.create_class):
+            r = Runner(options={})
+            volume1 = '11111111-1111-1111-1111-111111111111'
+            volume2 = '22222222-2222-2222-2222-222222222222'
+            r.main(self.create_args +
+                   ['--volumes', '{0},{1}'.format(
+                    volume1,
+                    volume2)]
+                   )
+
+            call_args = self.create_command.execute.call_args_list[0][1]
+            self.assertEquals([volume1, volume2],
+                              call_args.get('volumes'))
+
     def test_create_with_template_includes_template(self):
         with mock.patch.multiple(
                 "littlechef_rackspace.runner",


### PR DESCRIPTION
This adds the ability to attach block storage volumes when creating a node.

Volume IDs can be passed in comma separated or put into the YAML config, just like networks.